### PR TITLE
Support for whitespaces in program paths

### DIFF
--- a/src/bawr/tool_fontforge.py
+++ b/src/bawr/tool_fontforge.py
@@ -26,7 +26,7 @@ class FontForgeTool:
         self.env = env
 
     def __call__(self, script_path):
-        process = subprocess.Popen('{} -lang=py -script {}'.format(self.env.FONTFORGE_PATH, script_path), shell=True)
+        process = subprocess.Popen([self.env.FONTFORGE_PATH, '-lang=py', '-script', script_path], shell=True)
         try:
             err = process.wait(30)
             if (err):

--- a/src/bawr/tool_inkscape.py
+++ b/src/bawr/tool_inkscape.py
@@ -29,11 +29,7 @@ class InkscapeTool:
         if margin > 0:
             size -= 2*margin
         
-        process = subprocess.Popen(f'''{self.env.INKSCAPE_PATH} \
-            --export-background-opacity=0 \
-            --export-width={size} \
-            --export-type=png \
-            --export-filename="{png_file}" "{svg_file}"''', shell=True)
+        process = subprocess.Popen([self.env.INKSCAPE_PATH, "--export-background-opacity=0", f"--export-width={size}", "--export-type=png", f"--export-filename={png_file}", svg_file], shell=True)
         try:
             err = process.wait(30)
             if (err):


### PR DESCRIPTION
The patch uses the array syntax  to spawn subprocesses to avoid the need to wrap arguments in quotes to keep whitespaces.
This is needed on Windows systems where you have programs installed in folders like "C:\Program Files\Inkscape".