### PR TITLE
add version attribute to font configuration

### DIFF
--- a/src/bawr/gen_font.py
+++ b/src/bawr/gen_font.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Frank David Martinez Muñoz
+# Copyright 2024 Lutz Schönemann
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in 
@@ -29,6 +30,7 @@ class Font:
     copyright = "Copyright 2021 Frank David Martinez M."
     name = "icons"
     family = "icons"
+    version = ''
     start_code = 0xe000
     collections = []
     transformation = []
@@ -78,6 +80,7 @@ class Font:
                 out.write("  font_copyright = '{}'\n".format(self.copyright))
                 out.write("  font_family = '{}'\n".format(self.family))
                 out.write("  font_name = '{}'\n".format(self.name))
+                out.write("  font_version = '{}'\n".format(self.version))
                 out.write("\n")
 
                 for icon_set_cls in utils.as_iterable(self.collections):

--- a/src/bawr/gen_font_ff_template.py
+++ b/src/bawr/gen_font_ff_template.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Frank David Martinez M.
+# Copyright 2024 Lutz Schönemann
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in 
@@ -65,6 +66,7 @@ font.copyright = config.font_copyright
 font.familyname = config.font_family
 font.fontname = config.font_name
 font.fullname = config.font_name
+font.version = config.font_version.strip() or font.version
 
 for code, name, path, options in select:
     glyph = font.createChar(code, name)


### PR DESCRIPTION
The new attribute is used to set the version string in the generated font file. If it is set to an empty string or a string that contains whitespaces only the configured value is ignored and the default version string from fontforge is used.